### PR TITLE
Fix handling of pydoc_cmd

### DIFF
--- a/ftplugin/python/detectversion.vim
+++ b/ftplugin/python/detectversion.vim
@@ -7,16 +7,14 @@ endif
 let shebang = getline(1)
 " Lax regex, to work on bare binary and env and whatever
 if shebang =~# '\<python3\>'
-	let p_version = '3'
+	let new_cmd = substitute(g:pydoc_cmd, '\v<(python|pydoc) ', '\13 ', '')
 else
-	let p_version = ''
+	let new_cmd = substitute(g:pydoc_cmd, '\v<(python|pydoc)3>', '\1', '')
 endif
 
 " Change the command
 " Just clobber the buffer, it's good to have the lastest info
 " For the tab variable, don't clobber
-let new_cmd = 'pydoc' . p_version
-
 let b:pydoc_cmd = new_cmd
 if !exists('t:pydoc_cmd')
 	let t:pydoc_cmd = new_cmd

--- a/plugin/pydoc.vim
+++ b/plugin/pydoc.vim
@@ -118,6 +118,9 @@ function! s:ShowPyDoc(name, type)
 		return
 	endif
 
+	" Grab the cmd from the buffer requesting pydoc.
+	let l:pydoc_cmd = get(b:, 'pydoc_cmd', get(t:, 'pydoc_cmd', g:pydoc_cmd))
+
 	if exists('t:pydoc_buffer')
 		let l:winnr = bufwinnr(t:pydoc_buffer)
 		if l:winnr != -1 && getwinvar(l:winnr, '&ft') ==# 'pydoc'
@@ -150,7 +153,6 @@ function! s:ShowPyDoc(name, type)
 	if a:type == 0
 		let l:pydoc_options .= ' -k'
 	endif
-	let l:pydoc_cmd = get(b:, 'pydoc_cmd', get(t:, 'pydoc_cmd', g:pydoc_cmd))
 	let s:cmd = l:pydoc_cmd .' '.l:pydoc_options.' '. shellescape(l:name)
 	if &verbose
 		echomsg "PyDoc: " s:cmd


### PR DESCRIPTION
Make detection work when t:pydoc_cmd exists. (Especially creating a new python file and then added a py3 shebang.)

Make detection use g:pydoc_cmd to determine the command to use. (Especially using `let g:pydoc_cmd = 'python -m pydoc'`)

Tested using python3 on Windows and vim8.